### PR TITLE
Feat stomp destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+.build/
+
 # User-specific files
 *.suo
 *.user

--- a/README.md
+++ b/README.md
@@ -102,3 +102,16 @@ This library is based on the [`SockJS-client`](https://github.com/sockjs/sockjs-
 Dependencies
 ------------
 - [`Newtonsoft.Json`](https://www.nuget.org/packages/Newtonsoft.Json) ([license](https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md))
+
+WIP
+---
+### STOMP Detinations
+
+Subscribing STOMP destinations can be achieved like this:
+````csharp
+await sockJs.Send("CONNECT\naccept-version:1.0,1.1,2.0\n\n\x00\n");
+await sockJs.Send("SUBSCRIBE\nid:sub-0\ndestination:/user/queue/topicname\n\n\0");
+await sockJs.Send("SEND\ndestination:/app/topicname\ncontent-length:\n\n"payload to be sent" \n\n\0");
+````
+
+TODO: Add APIs to suscribe from the `SockJS` object.

--- a/build.cmd
+++ b/build.cmd
@@ -4,7 +4,7 @@ echo ====== Cleaning build folder ======
 rm -f .build/*
 
 echo ====== Building syp.biz.SockJS.NET.Client ======
-dotnet build -c Release -o .build/ syp.biz\SockJS.NET\syp.biz.SockJS.NET.Client\
+dotnet build -c Release -o .build/ syp.biz\SockJS.NET\syp.biz.Stomp.Net.Client\
 
 echo ====== Pushing generated packages ======
 for %%v in (.build/*.nupkg) do nuget.exe push -Source "Synexie-packages" -ApiKey AzureDevOps .build/%%v

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,10 @@
+@echo off
+
+echo ====== Cleaning build folder ======
+rm -f .build/*
+
+echo ====== Building syp.biz.SockJS.NET.Client ======
+dotnet build -c Release -o .build/ syp.biz\SockJS.NET\syp.biz.SockJS.NET.Client\
+
+echo ====== Pushing generated packages ======
+for %%v in (.build/*.nupkg) do nuget.exe push -Source "Synexie-packages" -ApiKey AzureDevOps .build/%%v

--- a/syp.biz.SockJS.NET.sln
+++ b/syp.biz.SockJS.NET.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "syp.biz.SockJS.NET.Test", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "syp.biz.SockJS.NET.Client", "syp.biz\SockJS.NET\syp.biz.SockJS.NET.Client\syp.biz.SockJS.NET.Client.csproj", "{6C251580-20BE-4523-8062-C7C222B7FA42}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "syp.biz.Stomp.Net.Client", "syp.biz\SockJS.NET\syp.biz.Stomp.Net.Client\syp.biz.Stomp.Net.Client.csproj", "{E285B770-F9B1-4ED4-931B-8201DA5D8D8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{6C251580-20BE-4523-8062-C7C222B7FA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C251580-20BE-4523-8062-C7C222B7FA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C251580-20BE-4523-8062-C7C222B7FA42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E285B770-F9B1-4ED4-931B-8201DA5D8D8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E285B770-F9B1-4ED4-931B-8201DA5D8D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E285B770-F9B1-4ED4-931B-8201DA5D8D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E285B770-F9B1-4ED4-931B-8201DA5D8D8D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Client/syp.biz.SockJS.NET.Client.csproj
+++ b/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Client/syp.biz.SockJS.NET.Client.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>NU1605;CS8625;CS8600;CS8602</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>..\..\..\syp.biz.SockJS.NET.pfx</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
@@ -16,7 +16,7 @@
     <PackageId>syp.biz.SockJS.NET.Client</PackageId>
     <Description>An asynchronous .NET implementation of the SockJS client</Description>
     <Product>SockJS.NET.Client</Product>
-    <Version>2.0.0</Version>
+    <Version>2.0.226</Version>
     <Authors>syp.biz</Authors>
     <Company>syp.biz</Company>
     <PackageProjectUrl>https://github.com/sypbiz/SockJS.NET</PackageProjectUrl>

--- a/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Common/syp.biz.SockJS.NET.Common.csproj
+++ b/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Common/syp.biz.SockJS.NET.Common.csproj
@@ -16,7 +16,7 @@
     <PackageId>syp.biz.SockJS.NET.Common</PackageId>
     <Description>An asynchronous .NET implementation of the SockJS client</Description>
     <Product>SockJS.NET.Common</Product>
-    <Version>2.0.226</Version>
+    <Version>2.1.227</Version>
     <Authors>syp.biz</Authors>
     <Company>syp.biz</Company>
     <PackageProjectUrl>https://github.com/sypbiz/SockJS.NET</PackageProjectUrl>

--- a/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Common/syp.biz.SockJS.NET.Common.csproj
+++ b/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Common/syp.biz.SockJS.NET.Common.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>NU1605;CS8625;CS8600;CS8602</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>..\..\..\syp.biz.SockJS.NET.pfx</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
@@ -16,7 +16,7 @@
     <PackageId>syp.biz.SockJS.NET.Common</PackageId>
     <Description>An asynchronous .NET implementation of the SockJS client</Description>
     <Product>SockJS.NET.Common</Product>
-    <Version>2.0.0</Version>
+    <Version>2.0.226</Version>
     <Authors>syp.biz</Authors>
     <Company>syp.biz</Company>
     <PackageProjectUrl>https://github.com/sypbiz/SockJS.NET</PackageProjectUrl>

--- a/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/IStompClient.cs
+++ b/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/IStompClient.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using syp.biz.SockJS.NET.Common.Interfaces;
+
+namespace syp.biz.Stomp.Net.Client
+{
+    public interface IStompClient : IClient
+    {
+        Task SetApiKey(string apiKey, CancellationToken token);
+        Task SetApiKey(string apiKey);
+        Task Subscribe(string destination, CancellationToken token);
+        Task Subscribe(string destination);
+    }
+}

--- a/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/StompClient.cs
+++ b/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/StompClient.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using syp.biz.SockJS.NET.Client;
+
+namespace syp.biz.Stomp.Net.Client
+{
+    public class StompClient : SockJS.NET.Client.SockJS, IStompClient
+    {
+        #region Constructors
+        public StompClient(string baseEndpoint) : 
+            base(baseEndpoint)
+        {
+        }
+
+        public StompClient(Uri baseEndpoint) : 
+            base(baseEndpoint)
+        {
+        }
+
+        public StompClient(Configuration config) : 
+            base(config)
+        {
+        }
+        #endregion
+
+        public async Task SetApiKey(string apiKey) => await SetApiKey(apiKey, CancellationToken.None);
+        public async Task SetApiKey(string apiKey, CancellationToken token)
+        {
+            var message = $"CONNECT\napiKey:{apiKey}\naccept-version:1.1,1.0\nheart-beat:10000,10000\n\n\u0000";
+            await Send(message, token);
+        }
+
+        public async Task Subscribe(string destination) => await Subscribe(destination, CancellationToken.None);
+        public async Task Subscribe(string destination, CancellationToken token)
+        {
+            var message = $"SUBSCRIBE\nid:sub-0\ndestination:{destination}\n\n\u0000";
+            await Send(message, token);
+        }
+    }
+}

--- a/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/syp.biz.Stomp.Net.Client.csproj
+++ b/syp.biz/SockJS.NET/syp.biz.Stomp.Net.Client/syp.biz.Stomp.Net.Client.csproj
@@ -13,33 +13,30 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>syp.biz.SockJS.NET.Client</PackageId>
-    <Description>An asynchronous .NET implementation of the SockJS client</Description>
-    <Product>SockJS.NET.Client</Product>
+    <PackageId>syp.biz.Stomp.Net.Client</PackageId>
+    <Description>An asynchronous .NET implementation of the SockJS client with STOMP headers and destination subscribe</Description>
+    <Product>SockJS.NET.StompClient</Product>
     <Version>2.1.227</Version>
-    <Authors>syp.biz</Authors>
-    <Company>syp.biz</Company>
-    <PackageProjectUrl>https://github.com/sypbiz/SockJS.NET</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/sypbiz/SockJS.NET</RepositoryUrl>
+    <Authors>kall2Sollies</Authors>
+    <Company>Synexie</Company>
+    <PackageProjectUrl>https://github.com/kall2sollies/SockJS.NET</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/kall2sollies/SockJS.NET</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Copyright>Copyright (c) 2020 syp.biz</Copyright>
-    <PackageTags>SockJS; Client; .NET</PackageTags>
+    <Copyright>Copyright (c) 2021 Synexie</Copyright>
+    <PackageTags>SockJS; Client; .NET; STOMP</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\syp.biz.SockJS.NET.Common\syp.biz.SockJS.NET.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\..\LICENSE">
-      <Pack>True</Pack>
+    <None Include="..\..\..\LICENSE" Link="LICENSE">
       <PackagePath></PackagePath>
+      <Pack>True</Pack>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\syp.biz.SockJS.NET.Client\syp.biz.SockJS.NET.Client.csproj" />
+    <ProjectReference Include="..\syp.biz.SockJS.NET.Common\syp.biz.SockJS.NET.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In order to achieve STOMP connexion, I did the following:

* Created a third classlib `syp.biz.Stomp.Net.Client`
* Inherited `IClient` in `IStompClient`
* Inherited `SockJS` in `StompClient`
* interface exposes 2 new methods : `SetApiKey(string)` and `Subscribe(string)`
* These methods simply use `base.Send(string, [CancellationToken])` to pass the required messages

The `SEND` to a topic has not been achieved, since I have no test server that supports incoming messages (I did this for a customer project, their server is only sending messages, that's why).

I have disabled pfk signing of the built packages, and also changed the versions of the packages to 2.1.227 (I guess you will take charge of these points)