### PR TITLE
Fix to disconnect when there is an error on receiving loop

### DIFF
--- a/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Client/Implementations/Transports/SystemWebSocketTransport.cs
+++ b/syp.biz/SockJS.NET/syp.biz.SockJS.NET.Client/Implementations/Transports/SystemWebSocketTransport.cs
@@ -138,6 +138,7 @@ namespace syp.biz.SockJS.NET.Client.Implementations.Transports
             catch (Exception ex)
             {
                 this._log.Error($"{nameof(this.ReceiveLoop)}: {ex}");
+                await this.Disconnect();
             }
         }
 


### PR DESCRIPTION
If websocket connection is closed (by an external tool for example), ReceiveLoop will crash and there is no way to know that client needs to reconnect.